### PR TITLE
removing list style CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -15,8 +15,7 @@ div.dokuwiki .dt {
 }
 
 div.dokuwiki .dt,
-div.dokuwiki .dd,
-div.dokuwiki .li {
+div.dokuwiki .dd {
     margin-bottom: 0.33em;
 }
 


### PR DESCRIPTION
 Removing selectors "div.dokuwiki .li" (line 19) in order it not to interfere the default list style.
