### PR TITLE
Added ODT support. Fixes #1.

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @author LarsDW223
+ */
+
+// How shall definition lists be exported to ODT?
+$conf['def_list_odt_export'] = 'list';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Options for the yalist plugin
+ *
+ * @author LarsDW223
+ */
+
+$meta['def_list_odt_export'] = array('multichoice', '_choices' => array('list', 'listheader', 'table'));

--- a/odt.css
+++ b/odt.css
@@ -1,0 +1,7 @@
+div.dokuwiki .dt {
+    margin-right: 1em;
+    color: __text_alt__;
+    font-weight: bold;
+    max-width: 30%;
+    float: left;
+}


### PR DESCRIPTION
Here is a PR to implement ODT support.

As ODT does not support definition lists a configuration option has been added which gives the user the choice to render definition lists as:
- a normal list or
- a listheader list (like a normal list but without bullets, requires master branch of ODT plugin) or
- a table
